### PR TITLE
Use enum attribute to specify shape of CropView

### DIFF
--- a/scissors-sample/src/main/res/layout/activity_main.xml
+++ b/scissors-sample/src/main/res/layout/activity_main.xml
@@ -11,7 +11,6 @@
         android:layout_height="match_parent"
         app:cropviewViewportRatio="1"
         app:cropviewViewportOverlayPadding="8dp"
-        app:cropviewIsOval="true"
         />
 
     <android.support.design.widget.FloatingActionButton

--- a/scissors-sample/src/main/res/layout/activity_main.xml
+++ b/scissors-sample/src/main/res/layout/activity_main.xml
@@ -10,7 +10,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:cropviewViewportRatio="1"
-        app:cropviewViewportOverlayPadding="8dp"
         />
 
     <android.support.design.widget.FloatingActionButton

--- a/scissors/src/main/java/com/lyft/android/scissors/CropView.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropView.java
@@ -50,7 +50,7 @@ public class CropView extends ImageView {
     private TouchManager touchManager;
     private CropViewConfig config;
 
-    private Paint viewportPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private Paint viewportPaint = new Paint();
     private Paint bitmapPaint = new Paint();
 
     private Bitmap bitmap;
@@ -80,6 +80,11 @@ public class CropView extends ImageView {
         bitmapPaint.setFilterBitmap(true);
         setViewportOverlayColor(config.getViewportOverlayColor());
         shape = config.shape();
+
+        // If shape is not a rectangle, we need anti-aliased Paint to smooth the curved edges
+        if (shape != 0) {
+            viewportPaint.setFlags(viewportPaint.getFlags() | Paint.ANTI_ALIAS_FLAG);
+        }
     }
 
     @Override

--- a/scissors/src/main/java/com/lyft/android/scissors/CropView.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropView.java
@@ -129,46 +129,44 @@ public class CropView extends ImageView {
         ovalRect.right = right;
         ovalRect.bottom = bottom;
 
-        // top left
+        // top left arc
         ovalPath.reset();
         ovalPath.moveTo(left, getHeight() / 2); // middle of the left side of the circle
         ovalPath.arcTo(ovalRect, 180, 90, false); // draw arc to top
-        ovalPath.lineTo(left, top); // move to left corner
+        ovalPath.lineTo(left, top); // move to top-left corner
         ovalPath.lineTo(left, getHeight() / 2); // move back to origin
         ovalPath.close();
         canvas.drawPath(ovalPath, viewportPaint);
 
-        // top right
+        // top right arc
         ovalPath.reset();
-        ovalPath.moveTo(getWidth() / 2, top);
-        ovalPath.arcTo(ovalRect, 270, 90, false);
-        ovalPath.lineTo(right, top);
-        ovalPath.lineTo(getWidth() / 2, top);
+        ovalPath.moveTo(getWidth() / 2, top); // middle of the top side of the circle
+        ovalPath.arcTo(ovalRect, 270, 90, false); // draw arc to the right
+        ovalPath.lineTo(right, top); // move to top-right corner
+        ovalPath.lineTo(getWidth() / 2, top); // move back to origin
         ovalPath.close();
         canvas.drawPath(ovalPath, viewportPaint);
 
-        // bottom right
+        // bottom right arc
         ovalPath.reset();
-        ovalPath.moveTo(right, getHeight() / 2);
-        ovalPath.arcTo(ovalRect, 0, 90, false);
-        ovalPath.lineTo(right, bottom);
-        ovalPath.lineTo(right, getHeight() / 2);
+        ovalPath.moveTo(right, getHeight() / 2); // middle of the right side of the circle
+        ovalPath.arcTo(ovalRect, 0, 90, false); // draw arc to the bottom
+        ovalPath.lineTo(right, bottom); // move to bottom-right corner
+        ovalPath.lineTo(right, getHeight() / 2); // move back to origin
         ovalPath.close();
         canvas.drawPath(ovalPath, viewportPaint);
 
-        // bottom left
+        // bottom left arc
         ovalPath.reset();
-        ovalPath.moveTo(getWidth() / 2, bottom);
-        ovalPath.arcTo(ovalRect, 90, 90, false);
-        ovalPath.lineTo(left, bottom);
-        ovalPath.lineTo(getWidth() / 2, bottom);
+        ovalPath.moveTo(getWidth() / 2, bottom); // middle of the bottom side of the circle
+        ovalPath.arcTo(ovalRect, 90, 90, false); // draw arc to the left
+        ovalPath.lineTo(left, bottom); // move to bottom-left corner
+        ovalPath.lineTo(getWidth() / 2, bottom); // move back to origin
         ovalPath.close();
         canvas.drawPath(ovalPath, viewportPaint);
 
-        canvas.drawRect(0, top, left, getHeight() - top, viewportPaint); // left
-        canvas.drawRect(0, 0, getWidth(), top, viewportPaint); // top
-        canvas.drawRect(getWidth() - left, top, getWidth(), getHeight() - top, viewportPaint); // right
-        canvas.drawRect(0, getHeight() - top, getWidth(), getHeight(), viewportPaint); // bottom
+        // Draw the square overlay as well
+        drawSquareOverlay(canvas);
     }
 
     @Override

--- a/scissors/src/main/java/com/lyft/android/scissors/CropView.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropView.java
@@ -57,7 +57,7 @@ public class CropView extends ImageView {
     private Matrix transform = new Matrix();
     private Extensions extensions;
 
-    private boolean isOval = false;
+    private int shape = 0;
     private Path ovalPath = new Path();
     private RectF ovalRect = new RectF();
 
@@ -79,7 +79,7 @@ public class CropView extends ImageView {
 
         bitmapPaint.setFilterBitmap(true);
         setViewportOverlayColor(config.getViewportOverlayColor());
-        isOval = config.isOval();
+        shape = config.shape();
     }
 
     @Override
@@ -91,10 +91,10 @@ public class CropView extends ImageView {
         }
 
         drawBitmap(canvas);
-        if (isOval) {
-            drawOvalOverlay(canvas);
-        } else {
+        if (shape == 0) {
             drawSquareOverlay(canvas);
+        } else {
+            drawOvalOverlay(canvas);
         }
     }
 

--- a/scissors/src/main/java/com/lyft/android/scissors/CropViewConfig.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropViewConfig.java
@@ -27,14 +27,14 @@ class CropViewConfig {
     public static final int DEFAULT_IMAGE_QUALITY = 100;
     public static final int DEFAULT_VIEWPORT_OVERLAY_PADDING = 0;
     public static final int DEFAULT_VIEWPORT_OVERLAY_COLOR = 0xC8000000; // Black with 200 alpha
-    public static final boolean DEFAULT_IS_OVAL = false;
+    public static final int DEFAULT_SHAPE = 0;
 
     private float viewportRatio = DEFAULT_VIEWPORT_RATIO;
     private float maxScale = DEFAULT_MAXIMUM_SCALE;
     private float minScale = DEFAULT_MINIMUM_SCALE;
     private int viewportOverlayPadding = DEFAULT_VIEWPORT_OVERLAY_PADDING;
     private int viewportOverlayColor = DEFAULT_VIEWPORT_OVERLAY_COLOR;
-    private boolean isOval = DEFAULT_IS_OVAL;
+    private int shape = DEFAULT_SHAPE;
 
     public int getViewportOverlayColor() {
         return viewportOverlayColor;
@@ -76,12 +76,12 @@ class CropViewConfig {
         this.minScale = minScale <= 0 ? DEFAULT_MINIMUM_SCALE : minScale;
     }
 
-    public boolean isOval() {
-        return isOval;
+    public int shape() {
+        return shape;
     }
 
-    public void setOval(boolean isOval) {
-        this.isOval = isOval;
+    public void setShape(int shape) {
+        this.shape = shape;
     }
 
     public static CropViewConfig from(Context context, AttributeSet attrs) {
@@ -115,9 +115,9 @@ class CropViewConfig {
             attributes.getDimensionPixelSize(R.styleable.CropView_cropviewViewportOverlayPadding,
                 CropViewConfig.DEFAULT_VIEWPORT_OVERLAY_PADDING));
 
-        cropViewConfig.setOval(
-            attributes.getBoolean(R.styleable.CropView_cropviewIsOval,
-                CropViewConfig.DEFAULT_IS_OVAL));
+        cropViewConfig.setShape(
+                attributes.getInt(R.styleable.CropView_cropviewShape,
+                        CropViewConfig.DEFAULT_SHAPE));
 
         attributes.recycle();
 

--- a/scissors/src/main/java/com/lyft/android/scissors/CropViewExtensions.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropViewExtensions.java
@@ -147,6 +147,13 @@ class CropViewExtensions {
             return this;
         }
 
+        /**
+         * Maximum dimensions of the output image. By default, the output image is not downscaled.
+         *
+         * @param width Maximum width in pixels
+         * @param height Maximum height in pixels
+         * @return current request for chaining.
+         */
         public CropRequest dimensions(int width, int height) {
             Utils.checkArg(width >= 0 && height >= 0, "requested width and height must be >= 0");
             this.requestedWidth = width;

--- a/scissors/src/main/res/values/attrs.xml
+++ b/scissors/src/main/res/values/attrs.xml
@@ -12,6 +12,9 @@
         <!-- Minimum  zoom level -->
         <attr name="cropviewMinScale" format="float" />
         <!-- Shape -->
-        <attr name="cropviewIsOval" format="boolean" />
+        <attr name="cropviewShape" format="enum">
+            <enum name="rectangle" value="0" />
+            <enum name="oval" value="1" />
+        </attr>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Cleaning this up to submit a PR upstream

- [x] QA @damien5314

### Changes
- Boolean attribute `cropviewIsOval` is now an enum attribute `cropviewShape` with possible values `rectangle` and `oval`
- Add comments to new `dimensions()` API in CropRequest
- Revert changes in sample app

### Test Plan
- Verify CropView works as before when `cropviewShape` value is specified as rectangle, oval, or not included