### PR TITLE
[MONEY-3008] Fix crash while calling GlideBitmapLoader#skipMemoryCache()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,34 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.jakewharton:butterknife-gradle-plugin:10.1.0'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
     }
 }
 
 ext {
     minSdkVersion = 14
-    compileSdkVersion = 24
-    buildToolsVersion = '24.0.3'
+    compileSdkVersion = 28
+    buildToolsVersion = '28.0.3'
 
     junitVersion = '4.12'
     mockitoVersion = '1.10.19'
     robolectricVersion = '3.0'
     assertjVersion = '1.7.1'
-    supportVersion = '24.2.1'
+    androidxVersion = '1.0.0'
+    glideVersion = '4.9.0'
+    butterknifeVersion = '10.1.0'
 
     ci = 'true'.equals(System.getenv('CI'))
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath 'com.jakewharton:butterknife-gradle-plugin:10.1.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=lyft
 POM_DEVELOPER_NAME=Lyft Open Source
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 14 17:41:18 PDT 2016
+#Wed Mar 27 16:49:15 BRT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/scissors-sample/build.gradle
+++ b/scissors-sample/build.gradle
@@ -15,8 +15,8 @@ android {
         disable 'InvalidPackage'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     dexOptions {
@@ -25,16 +25,22 @@ android {
 }
 
 dependencies {
-    compile project(':scissors')
-    compile 'com.android.support:appcompat-v7:' + rootProject.ext.supportVersion
-    compile 'com.android.support:design:' + rootProject.ext.supportVersion
-    compile 'com.jakewharton:butterknife:7.0.1'
-    compile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
-    compile 'com.squareup.picasso:picasso:2.5.2'
+    implementation project(':scissors')
+    // AndroidX
+    implementation 'androidx.appcompat:appcompat:' + rootProject.ext.androidxVersion
+    implementation 'com.google.android.material:material:1.0.0-rc01'
+    // Butterknife
+    implementation 'com.jakewharton:butterknife:' + rootProject.ext.butterknifeVersion
+    annotationProcessor 'com.jakewharton:butterknife-compiler:' + rootProject.ext.butterknifeVersion
+    implementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    // Picasso
+    //implementation 'com.squareup.picasso:picasso:2.5.2'
     // Or Glide
-    // compile 'com.github.bumptech.glide:glide:3.6.1'
+    implementation 'com.github.bumptech.glide:glide:' + rootProject.ext.glideVersion
+    annotationProcessor 'com.github.bumptech.glide:compiler:' + rootProject.ext.glideVersion
     // Or Android-Universal-Image-Loader
-    // compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.4'
-    compile 'io.reactivex:rxjava:1.0.15'
-    compile 'io.reactivex:rxandroid:1.0.1'
+    // implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.4'
+    // RxJava
+    implementation 'io.reactivex:rxjava:1.0.15'
+    implementation 'io.reactivex:rxandroid:1.0.1'
 }

--- a/scissors-sample/build.gradle
+++ b/scissors-sample/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.jakewharton.butterknife'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -34,10 +35,10 @@ dependencies {
     annotationProcessor 'com.jakewharton:butterknife-compiler:' + rootProject.ext.butterknifeVersion
     implementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
     // Picasso
-    //implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
     // Or Glide
-    implementation 'com.github.bumptech.glide:glide:' + rootProject.ext.glideVersion
-    annotationProcessor 'com.github.bumptech.glide:compiler:' + rootProject.ext.glideVersion
+    //implementation 'com.github.bumptech.glide:glide:' + rootProject.ext.glideVersion
+    //annotationProcessor 'com.github.bumptech.glide:compiler:' + rootProject.ext.glideVersion
     // Or Android-Universal-Image-Loader
     // implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.4'
     // RxJava

--- a/scissors-sample/build.gradle
+++ b/scissors-sample/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.jakewharton.butterknife'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/scissors-sample/src/main/java/com/lyft/android/scissorssample/CropResultActivity.java
+++ b/scissors-sample/src/main/java/com/lyft/android/scissorssample/CropResultActivity.java
@@ -19,11 +19,13 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.ImageView;
+
+import com.squareup.picasso.MemoryPolicy;
+import com.squareup.picasso.Picasso;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import java.io.File;
 
 public class CropResultActivity extends Activity {
@@ -43,17 +45,17 @@ public class CropResultActivity extends Activity {
         String filePath = getIntent().getStringExtra(EXTRA_FILE_PATH);
         File imageFile = new File(filePath);
 
-//        Picasso.with(this)
-//                .load(imageFile)
-//                .memoryPolicy(MemoryPolicy.NO_CACHE, MemoryPolicy.NO_STORE)
-//                .into(resultView);
+        Picasso.with(this)
+                .load(imageFile)
+                .memoryPolicy(MemoryPolicy.NO_CACHE, MemoryPolicy.NO_STORE)
+                .into(resultView);
 
         // Or Glide
-        Glide.with(this)
-                .load(imageFile)
-                .diskCacheStrategy(DiskCacheStrategy.NONE)
-                .skipMemoryCache(true)
-                .into(resultView);
+        //Glide.with(this)
+        //        .load(imageFile)
+        //        .diskCacheStrategy(DiskCacheStrategy.NONE)
+        //        .skipMemoryCache(true)
+        //        .into(resultView);
 
         // Or Android-Universal-Image-Loader
         //DisplayImageOptions options = new DisplayImageOptions.Builder()

--- a/scissors-sample/src/main/java/com/lyft/android/scissorssample/CropResultActivity.java
+++ b/scissors-sample/src/main/java/com/lyft/android/scissorssample/CropResultActivity.java
@@ -19,17 +19,18 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.ImageView;
-import butterknife.Bind;
+import butterknife.BindView;
 import butterknife.ButterKnife;
-import com.squareup.picasso.MemoryPolicy;
-import com.squareup.picasso.Picasso;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import java.io.File;
 
 public class CropResultActivity extends Activity {
 
     private static final String EXTRA_FILE_PATH = "EXTRA_FILE_PATH";
 
-    @Bind(R.id.result_image)
+    @BindView(R.id.result_image)
     ImageView resultView;
 
     @Override
@@ -42,17 +43,17 @@ public class CropResultActivity extends Activity {
         String filePath = getIntent().getStringExtra(EXTRA_FILE_PATH);
         File imageFile = new File(filePath);
 
-        Picasso.with(this)
-                .load(imageFile)
-                .memoryPolicy(MemoryPolicy.NO_CACHE, MemoryPolicy.NO_STORE)
-                .into(resultView);
+//        Picasso.with(this)
+//                .load(imageFile)
+//                .memoryPolicy(MemoryPolicy.NO_CACHE, MemoryPolicy.NO_STORE)
+//                .into(resultView);
 
         // Or Glide
-        //Glide.with(this)
-        //        .load(imageFile)
-        //        .diskCacheStrategy(DiskCacheStrategy.NONE)
-        //        .skipMemoryCache(true)
-        //        .into(resultView);
+        Glide.with(this)
+                .load(imageFile)
+                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                .skipMemoryCache(true)
+                .into(resultView);
 
         // Or Android-Universal-Image-Loader
         //DisplayImageOptions options = new DisplayImageOptions.Builder()

--- a/scissors-sample/src/main/java/com/lyft/android/scissorssample/MainActivity.java
+++ b/scissors-sample/src/main/java/com/lyft/android/scissorssample/MainActivity.java
@@ -35,10 +35,13 @@ import com.squareup.leakcanary.RefWatcher;
 import java.io.File;
 import java.util.List;
 
-import butterknife.Bind;
+import butterknife.BindView;
+import butterknife.BindViews;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.OnTouch;
+import butterknife.Setter;
+import butterknife.ViewCollections;
 import rx.Observable;
 import rx.functions.Action1;
 import rx.subscriptions.CompositeSubscription;
@@ -49,17 +52,17 @@ import static rx.schedulers.Schedulers.io;
 
 public class MainActivity extends Activity {
 
-    private static final float[] ASPECT_RATIOS = { 0f, 1f, 6f/4f, 16f/9f };
+    private static final float[] ASPECT_RATIOS = {0f, 1f, 6f / 4f, 16f / 9f};
 
-    private static final String[] ASPECT_LABELS = { "\u00D8", "1:1", "6:4", "16:9" };
+    private static final String[] ASPECT_LABELS = {"\u00D8", "1:1", "6:4", "16:9"};
 
-    @Bind(R.id.crop_view)
+    @BindView(R.id.crop_view)
     CropView cropView;
 
-    @Bind({ R.id.crop_fab, R.id.pick_mini_fab, R.id.ratio_fab })
+    @BindViews({ R.id.crop_fab, R.id.pick_mini_fab, R.id.ratio_fab })
     List<View> buttons;
 
-    @Bind(R.id.pick_fab)
+    @BindView(R.id.pick_fab)
     View pickButton;
 
     CompositeSubscription subscriptions = new CompositeSubscription();
@@ -68,12 +71,12 @@ public class MainActivity extends Activity {
     private AnimatorListener animatorListener = new AnimatorListener() {
         @Override
         public void onAnimationStart(Animator animation) {
-            ButterKnife.apply(buttons, VISIBILITY, View.INVISIBLE);
+            ViewCollections.set(buttons, VISIBILITY, View.INVISIBLE);
         }
 
         @Override
         public void onAnimationEnd(Animator animation) {
-            ButterKnife.apply(buttons, VISIBILITY, View.VISIBLE);
+            ViewCollections.set(buttons, VISIBILITY, View.VISIBLE);
         }
 
         @Override
@@ -131,7 +134,7 @@ public class MainActivity extends Activity {
                 }));
     }
 
-    @OnClick({ R.id.pick_fab, R.id.pick_mini_fab })
+    @OnClick({R.id.pick_fab, R.id.pick_mini_fab})
     public void onPickClicked() {
         cropView.extensions()
                 .pickUsing(this, RequestCodes.PICK_IMAGE_FROM_GALLERY);
@@ -178,21 +181,21 @@ public class MainActivity extends Activity {
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_DOWN:
             case MotionEvent.ACTION_MOVE:
-                ButterKnife.apply(buttons, VISIBILITY, View.INVISIBLE);
+                ViewCollections.set(buttons, VISIBILITY, View.INVISIBLE);
                 break;
             default:
-                ButterKnife.apply(buttons, VISIBILITY, View.VISIBLE);
+                ViewCollections.set(buttons, VISIBILITY, View.VISIBLE);
                 break;
         }
         return true;
     }
 
     private void updateButtons() {
-        ButterKnife.apply(buttons, VISIBILITY, View.VISIBLE);
+        ViewCollections.set(buttons, VISIBILITY, View.VISIBLE);
         pickButton.setVisibility(View.GONE);
     }
 
-    static final ButterKnife.Setter<View, Integer> VISIBILITY = new ButterKnife.Setter<View, Integer>() {
+    static final Setter<View, Integer> VISIBILITY = new Setter<View, Integer>() {
         @Override
         public void set(final View view, final Integer visibility, int index) {
             view.setVisibility(visibility);

--- a/scissors-sample/src/main/res/layout/activity_main.xml
+++ b/scissors-sample/src/main/res/layout/activity_main.xml
@@ -12,7 +12,7 @@
         app:cropviewViewportRatio="1"
         />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/crop_fab"
         style="@style/FloatingActionButton"
         android:layout_width="wrap_content"
@@ -22,7 +22,7 @@
         android:src="@drawable/ic_content_content_cut"
         android:visibility="gone" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/pick_mini_fab"
         style="@style/FloatingActionButton"
         android:layout_width="wrap_content"
@@ -33,7 +33,7 @@
         android:visibility="gone"
         app:fabSize="mini" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/pick_fab"
         style="@style/FloatingActionButton"
         android:layout_width="wrap_content"
@@ -42,7 +42,7 @@
         android:layout_margin="16dp"
         android:src="@drawable/ic_content_add" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/ratio_fab"
         style="@style/FloatingActionButton"
         android:layout_width="wrap_content"

--- a/scissors/build.gradle
+++ b/scissors/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.jakewharton.butterknife'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -21,19 +22,19 @@ android {
 
 dependencies {
     // Test
-    testCompile 'junit:junit:' + rootProject.ext.junitVersion
-    testCompile 'org.mockito:mockito-core:' + rootProject.ext.mockitoVersion
-    testCompile 'org.robolectric:robolectric:' + rootProject.ext.robolectricVersion
-    testCompile 'org.assertj:assertj-core:' + rootProject.ext.assertjVersion
+    testImplementation 'junit:junit:' + rootProject.ext.junitVersion
+    testImplementation 'org.mockito:mockito-core:' + rootProject.ext.mockitoVersion
+    testImplementation 'org.robolectric:robolectric:' + rootProject.ext.robolectricVersion
+    testImplementation 'org.assertj:assertj-core:' + rootProject.ext.assertjVersion
     // Support Annotations
-    compile 'com.android.support:support-annotations:' + rootProject.ext.supportVersion
+    implementation 'androidx.annotation:annotation:' + rootProject.ext.androidxVersion
     // Optional dependencies for extensions
     // Picasso
-    provided 'com.squareup.picasso:picasso:[2.4.0, 2.5.2)'
+    compileOnly 'com.squareup.picasso:picasso:[2.4.0, 2.5.2)'
     // Glide
-    provided 'com.github.bumptech.glide:glide:4.1.1'
-    provided 'com.nostra13.universalimageloader:universal-image-loader:[1.9.2, 1.9.5)'
-    provided 'com.android.support:support-v4:' + rootProject.ext.supportVersion
+    compileOnly 'com.github.bumptech.glide:glide:' + rootProject.ext.glideVersion
+    compileOnly 'com.nostra13.universalimageloader:universal-image-loader:[1.9.2, 1.9.5)'
+    compileOnly 'androidx.legacy:legacy-support-v4:' + rootProject.ext.androidxVersion
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/scissors/build.gradle
+++ b/scissors/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.jakewharton.butterknife'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/scissors/src/main/java/com/lyft/android/scissors/BitmapLoader.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/BitmapLoader.java
@@ -15,9 +15,10 @@
  */
 package com.lyft.android.scissors;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.widget.ImageView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Load extension delegates actual Bitmap loading to a BitmapLoader allowing it to use different implementations.

--- a/scissors/src/main/java/com/lyft/android/scissors/CropView.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropView.java
@@ -15,6 +15,7 @@
  */
 package com.lyft.android.scissors;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
@@ -29,10 +30,6 @@ import android.graphics.RectF;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.support.annotation.ColorInt;
-import android.support.annotation.DrawableRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.widget.ImageView;
@@ -40,6 +37,11 @@ import com.lyft.android.scissors.CropViewExtensions.CropRequest;
 import com.lyft.android.scissors.CropViewExtensions.LoadRequest;
 import java.io.File;
 import java.io.OutputStream;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * An {@link ImageView} with a fixed viewport and cropping capabilities.
@@ -236,6 +238,7 @@ public class CropView extends ImageView {
     }
 
     @Override
+    @SuppressLint("ResourceType")
     public void setImageResource(@DrawableRes int resId) {
         final Bitmap bitmap = resId > 0
                 ? BitmapFactory.decodeResource(getResources(), resId)

--- a/scissors/src/main/java/com/lyft/android/scissors/CropViewExtensions.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropViewExtensions.java
@@ -20,13 +20,14 @@ import android.app.Fragment;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.ViewTreeObserver;
 
 import java.io.File;
 import java.io.OutputStream;
 import java.util.concurrent.Future;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 class CropViewExtensions {
 
@@ -150,7 +151,7 @@ class CropViewExtensions {
         /**
          * Maximum dimensions of the output image. By default, the output image is not downscaled.
          *
-         * @param width Maximum width in pixels
+         * @param width  Maximum width in pixels
          * @param height Maximum height in pixels
          * @return current request for chaining.
          */
@@ -176,7 +177,7 @@ class CropViewExtensions {
         /**
          * Asynchronously flush cropped bitmap into provided stream.
          *
-         * @param outputStream Stream to write to
+         * @param outputStream  Stream to write to
          * @param closeWhenDone wetter or not to close provided stream once flushing is done
          * @return {@link Future} used to cancel or wait for this request.
          */

--- a/scissors/src/main/java/com/lyft/android/scissors/GlideBitmapLoader.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/GlideBitmapLoader.java
@@ -15,8 +15,6 @@
  */
 package com.lyft.android.scissors;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
@@ -24,6 +22,9 @@ import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation;
 import com.bumptech.glide.request.RequestOptions;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * A {@link BitmapLoader} with transformation for {@link Glide} image library.

--- a/scissors/src/main/java/com/lyft/android/scissors/PicassoBitmapLoader.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/PicassoBitmapLoader.java
@@ -16,13 +16,14 @@
 package com.lyft.android.scissors;
 
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.widget.ImageView;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.RequestCreator;
 import com.squareup.picasso.Transformation;
 import java.io.File;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * A {@link BitmapLoader} with transformation for {@link Picasso} image library.

--- a/scissors/src/main/java/com/lyft/android/scissors/UILBitmapLoader.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/UILBitmapLoader.java
@@ -1,12 +1,13 @@
 package com.lyft.android.scissors;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.widget.ImageView;
 
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.display.BitmapDisplayer;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * A {@link BitmapLoader} with transformation for {@link ImageLoader} image library.

--- a/scissors/src/main/java/com/lyft/android/scissors/Utils.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/Utils.java
@@ -19,7 +19,6 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
-import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.io.File;
@@ -28,6 +27,8 @@ import java.io.OutputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
+import androidx.annotation.Nullable;
 
 class Utils {
 


### PR DESCRIPTION
Addresses [MONEY-3008](https://quizlet.atlassian.net/browse/MONEY-3008)

### Why this change is needed?
This PR is a fix for a crash that was happening when user was trying to change image profile. This issue was being caused due to a `NoSuchMethodError` which was thrown when calling `GlideBitmapLoader#skipMemoryCache()`, because Scissors fork uses out-of-date version of Glide and that it’s using the old/deprecated provided‌API to consume Glide stuff, getting linked to the wrong virtual methods.

### What has changed in this PR?
- Update the quizlet/scissors fork to use Android Gradle Plugin 3.3.2 and switch the dependencies using compile to implementation, and the dependencies using provided to compileOnly
- Update the version of Glide in quizlet/scissors to match what we have in quizlet-android
- Update scissors-sample to use the latest version of Glide and confirm that that a proguarded version of the sample app works
- Update our quizlet-android app to use the new version of quizlet/scissors
- Bumped up lib versions that were far away behind
- Added support to AndroidX that was being required when using 28.0.3 build tools
- Updated all classes to use AndroidX packages

### What are trade-offs or considered alternatives? 
No trade-offs.
### How to test it?
1. Login with user
2. Go on Profile
3. click on profile pic to change
4. take new pic